### PR TITLE
fix(types): IOSScriptPhase accepts "always_out_of_date"

### DIFF
--- a/packages/cli-types/src/ios.ts
+++ b/packages/cli-types/src/ios.ts
@@ -48,6 +48,7 @@ export type IOSScriptPhase = ({script: string} | {path: string}) & {
   input_file_lists?: string[];
   output_file_lists?: string[];
   show_env_vars_in_log?: boolean;
-  dependency_file?: string;
   execution_position?: 'before_compile' | 'after_compile' | 'any';
+  dependency_file?: string;
+  always_out_of_date?: string;
 };


### PR DESCRIPTION
Summary:
---------

This is useful to quiet the `pod install` warning:

"Run script build phase 'Create Symlinks to Header Folders' will be run during every build because..."

It already exists and works (parses correctly, is carried correctly through native_modules.rb, pod install consumes it and behaves correctly) as an attribute in the type - this just exposes it

ref https://www.rubydoc.info/gems/cocoapods-core/Pod/Podfile/DSL#script_phase-instance_method

I took the opportunity to move the dependency_file attr below execution_phase, so now the order of attributes matches upstream reference documentation order

Test Plan:
----------

react-native-firebase has two script phases that depend on inputs but can't specify output because it would duplicate the output. The scripts themselves are idempotent so it is okay if they re-run but not okay if they never run, so just run them every time is the answer, but it would be nice not to have the xcodebuild warning about it running every time. This parameter of the script phase is how to do it

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
